### PR TITLE
Import KaTeX CSS from modules

### DIFF
--- a/src/content/docs/recipes/math-support-in-markdown.mdx
+++ b/src/content/docs/recipes/math-support-in-markdown.mdx
@@ -28,7 +28,7 @@ import { Steps } from "@astrojs/starlight/components";
    export default defineConfig({
      integrations: [
        starlight({
-         customCss: ["./src/styles/custom.css"],
+         customCss: ["katex/dist/katex.min.css"],
        }),
      ],
      markdown: {
@@ -41,12 +41,6 @@ import { Steps } from "@astrojs/starlight/components";
        },
      },
    });
-   ```
-
-3. Add CSS
-   ```css
-   // src/styles/custom.css
-   @import url(katex/dist/katex.min.css);
    ```
 
 </Steps>


### PR DESCRIPTION
I believe importing KaTeX CSS from modules is easier than adding it to a CSS file.